### PR TITLE
TALCustomScrollBox - Best compatibility with the original TCustomScrollBox

### DIFF
--- a/source/ALFmxLayouts.pas
+++ b/source/ALFmxLayouts.pas
@@ -134,6 +134,7 @@ type
     function CreateContent: TALScrollBoxContent; virtual;
     function CreateAniCalculations: TALScrollBoxAniCalculations; virtual;
     function CalcContentBounds: TRectF; virtual;
+    function IsAddToContent(const AObject: TFmxObject): Boolean; virtual;
     procedure MouseDown(Button: TMouseButton; Shift: TShiftState; X, Y: Single); override;
     procedure MouseMove(Shift: TShiftState; X, Y: Single); override;
     procedure MouseUp(Button: TMouseButton; Shift: TShiftState; X, Y: Single); override;
@@ -851,6 +852,16 @@ begin
   end;
 end;
 
+{**********************************************}
+function TALCustomScrollBox.IsAddToContent(const AObject: TFmxObject): Boolean;
+begin
+  Result := (FContent <> nil) and
+     (AObject <> FContent) and
+     (not (AObject is TEffect)) and
+     (not (AObject is TAnimation)) and
+     (not (AObject is TALScrollBoxBar));
+end;
+
 {*********************************************************************************************}
 procedure TALCustomScrollBox.MouseDown(Button: TMouseButton; Shift: TShiftState; X, Y: Single);
 begin
@@ -956,11 +967,7 @@ end;
 {******************************************************************}
 procedure TALCustomScrollBox.DoAddObject(const AObject: TFmxObject);
 begin
-  if (FContent <> nil) and
-     (AObject <> FContent) and
-     (not (AObject is TEffect)) and
-     (not (AObject is TAnimation)) and
-     (not (AObject is TALScrollBoxBar)) then FContent.AddObject(AObject)
+  if IsAddToContent(AObject) then FContent.AddObject(AObject)
   else inherited;
 end;
 

--- a/source/ALFmxLayouts.pas
+++ b/source/ALFmxLayouts.pas
@@ -130,6 +130,7 @@ type
     procedure Loaded; override;
     procedure DoAddObject(const AObject: TFmxObject); override;
     procedure DoRealign; override;
+    procedure DoRealignContent(R: TRectF); virtual;
     function CreateScrollBar(const aOrientation: TOrientation): TALScrollBoxBar; virtual;
     function CreateContent: TALScrollBoxContent; virtual;
     function CreateAniCalculations: TALScrollBoxAniCalculations; virtual;
@@ -709,6 +710,7 @@ begin
         _UpdateHScrollBar(aContentRect);
         _UpdateAnimationTargets(aContentRect);
         fAniCalculations.DoChanged;
+        DoRealignContent(aContentRect);
       end
       else aDoRealignAgain := True;
     end;
@@ -719,6 +721,11 @@ begin
 
   if aDoRealignAgain then DoRealign;
 
+end;
+
+{*********************************************************************************************}
+procedure TALCustomScrollBox.DoRealignContent(R: TRectF);
+begin
 end;
 
 {*********************************************************************************************}


### PR DESCRIPTION
Dear stephane, 
I know you always prioritize performance, so you prefer not to call a new function, but this is necessary in some cases, like this one when we want to customize components that won't be in FContent, for example a static object; But anyway performance doesn't compromise because this is not a critical function like painting where it's called 60x per second...

Best regards