### PR TITLE
Fixed ALFmxInertialMovement in iOS

### DIFF
--- a/source/ALFmxInertialMovement.pas
+++ b/source/ALFmxInertialMovement.pas
@@ -361,10 +361,13 @@ end;
 {*******************************************************************}
 procedure TALAniCalculations.TDisplayLinkListener.displayLinkUpdated;
 begin
-  if assigned(fAniCalculations.fOnTimer) then
-    fAniCalculations.fOnTimer(fAniCalculations)
-  else
-    fAniCalculations.Calculate;
+  if not fAniCalculations.Down then
+  begin
+    if assigned(fAniCalculations.fOnTimer) then
+      fAniCalculations.fOnTimer(fAniCalculations)
+    else
+      fAniCalculations.Calculate;
+  end;
 end;
 
 {*****************************************************************************}


### PR DESCRIPTION
i'm not sure why it occurs but on ios the DisplayLink break when scrolling (mouse down). This raise a strange silent exception that can only be viewed in xcode console log (can't handle it in app), and than the scren flicker and draw incorrect. I found some complaints about this, such as https://stackoverflow.com/questions/5944050/cadisplaylink-opengl-rendering-breaks-uiscrollview-behaviour
![Assertion_alcinoe](https://user-images.githubusercontent.com/11139086/73006350-4440e780-3de9-11ea-8f50-c5907d1cbb6a.png)


But this can be avoided with this simple solution that works 100% since during the touch on the screen there is no animation, the animation is only done when the touch on the screen ends.